### PR TITLE
Fix ACL XML structure and permissions for WB_ExportProduct module

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0"?>
-<acl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
-    <resources>
-        <resource id="Magento_Backend::admin">
-            <resource id="WB_ExportProduct::main_menu" title="WB Export Products" sortOrder="10" />
-        </resource>
-    </resources>
-</acl>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="WB_ExportProduct::main_menu" title="WB Export Products" sortOrder="10">
+                    <resource id="WB_ExportProduct::view" title="View Export Products" sortOrder="10"/>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
Fix ACL XML structure and permissions for WB_ExportProduct module

- Corrected the root element in acl.xml from <acl> to <config> to comply with Magento's XML schema.
- Ensured the proper structure and permissions in acl.xml.
- Updated the permissions to include view access for WB Export Products.
- Verified and assigned the new permissions to the admin role.

This pull request resolves the issue where administrators were unable to access specific sections of the admin panel due to incorrect ACL configuration.

![image](https://github.com/user-attachments/assets/64aa14b3-1dba-4b12-82ff-208c105bffd5)

And the error:

```
1 exception(s):
Exception #0 (LogicException): Could not create an acl object: The XML in file "/home/magento/public_html/app/code/WB/ExportProduct/etc/acl.xml" is invalid:
Element 'acl': No matching global declaration available for the validation root.
Line: 2

Verify the XML and try again.

Exception #0 (LogicException): Could not create an acl object: The XML in file "/home/magento/public_html/app/code/WB/ExportProduct/etc/acl.xml" is invalid:
Element 'acl': No matching global declaration available for the validation root.
Line: 2
```